### PR TITLE
code cleanup

### DIFF
--- a/src/com/zoho/crm/library/api/APIRequest.php
+++ b/src/com/zoho/crm/library/api/APIRequest.php
@@ -1,11 +1,13 @@
 <?php
-require_once realpath(dirname(__FILE__)."/../common/ZCRMConfigUtil.php");
-require_once realpath(dirname(__FILE__)."/../common/ZohoHTTPConnector.php");
-require_once realpath(dirname(__FILE__)."/../common/APIConstants.php");
-require_once realpath(dirname(__FILE__)."/../exception/ZCRMException.php");
+
+require_once realpath(__DIR__."/../common/ZCRMConfigUtil.php");
+require_once realpath(__DIR__."/../common/ZohoHTTPConnector.php");
+require_once realpath(__DIR__."/../common/APIConstants.php");
+require_once realpath(__DIR__."/../exception/ZCRMException.php");
 require_once 'response/APIResponse.php';
 require_once 'response/BulkAPIResponse.php';
 require_once realpath(dirname(__FILE__)."/response/FileAPIResponse.php");
+
 /**
  * This class is to construct the API requests and initiate the request
  * @author sumanth-3058
@@ -13,14 +15,15 @@ require_once realpath(dirname(__FILE__)."/response/FileAPIResponse.php");
  */
 class APIRequest
 {
-	private $url=null;
-	private $requestParams=array();
-	private $requestHeaders=array();
+	private $url = null;
+	private $requestParams = array();
+	private $requestHeaders = array();
 	private $requestBody;
 	private $requestMethod;
-	private $apiKey=null;
-	private $response=null;
-	private $reponseInfo=null;
+	private $apiKey = null;
+	private $response = null;
+	private $reponseInfo = null;
+
 	private function __construct($apiHandler)
 	{
 		self::constructAPIUrl();
@@ -35,12 +38,13 @@ class APIRequest
 		self::setRequestMethod($apiHandler->getRequestMethod());
 		self::setApiKey($apiHandler->getApiKey());
 	}
-	
+
 	public static function getInstance($apiHandler)
 	{
 		$instance=new APIRequest($apiHandler);
 		return $instance;
 	}
+
 	/**
 	 * Method to construct the API Url
 	 */
@@ -51,8 +55,7 @@ class APIRequest
 		$this->url=$baseUrl."/crm/".ZCRMConfigUtil::getAPIVersion()."/";
 		$this->url=str_replace(PHP_EOL, '', $this->url);
 	}
-	
-	
+
 	private function authenticateRequest()
 	{
 		try{
@@ -63,6 +66,7 @@ class APIRequest
 			throw $ex;
 		}
 	}
+
 	/**
 	 * initiate the request and get the API response
 	 * @return Instance of APIResponse
@@ -88,7 +92,7 @@ class APIRequest
 			throw $e;
 		}
 	}
-	
+
 	/**
 	 * initiate the request and get the API response
 	 * @return instance of BulkAPIResponse
@@ -115,7 +119,7 @@ class APIRequest
 			throw $e;
 		}
 	}
-	
+
 	public function uploadFile($filePath)
 	{
 		try {
@@ -128,7 +132,7 @@ class APIRequest
 				$cFile = '@' . realpath($filePath);
 			}
 			$post = array('file'=> $cFile);
-				
+
 			$connector=ZohoHTTPConnector::getInstance();
 			$connector->setUrl($this->url);
 			self::authenticateRequest();
@@ -147,11 +151,12 @@ class APIRequest
 			throw $e;
 		}
 	}
+
 	public function uploadLinkAsAttachment($linkURL)
 	{
 		try {
 			$post = array('attachmentUrl'=> $linkURL);
-	
+
 			$connector=ZohoHTTPConnector::getInstance();
 			$connector->setUrl($this->url);
 			self::authenticateRequest();
@@ -169,7 +174,7 @@ class APIRequest
 			throw $e;
 		}
 	}
-	
+
 	public function downloadFile()
 	{
 		try {
@@ -282,6 +287,4 @@ class APIRequest
     public function setApiKey($apiKey){
         $this->apiKey = $apiKey;
     }
-
 }
-?>

--- a/src/com/zoho/crm/library/api/APIRequest.php
+++ b/src/com/zoho/crm/library/api/APIRequest.php
@@ -24,13 +24,11 @@ class APIRequest
 	private $response = null;
 	private $reponseInfo = null;
 
-	private function __construct($apiHandler)
-	{
+	private function __construct($apiHandler) {
 		self::constructAPIUrl();
 		self::setUrl($this->url.$apiHandler->getUrlPath());
-		if(substr($apiHandler->getUrlPath(),0,4)!=="http")
-		{
-			self::setUrl("https://".$this->url);
+		if (substr($apiHandler->getUrlPath(),0,4) !== 'http') {
+			self::setUrl("https://{$this->url}");
 		}
 		self::setRequestParams($apiHandler->getRequestParams());
 		self::setRequestHeaders($apiHandler->getRequestHeaders());
@@ -39,30 +37,27 @@ class APIRequest
 		self::setApiKey($apiHandler->getApiKey());
 	}
 
-	public static function getInstance($apiHandler)
-	{
-		$instance=new APIRequest($apiHandler);
+	public static function getInstance($apiHandler) {
+		$instance = new APIRequest($apiHandler);
 		return $instance;
 	}
 
 	/**
 	 * Method to construct the API Url
 	 */
-	public function constructAPIUrl()
-	{
-		$hitSandbox=ZCRMConfigUtil::getConfigValue('sandbox');
-		$baseUrl=strcasecmp($hitSandbox, "true")==0?str_replace('www','sandbox',ZCRMConfigUtil::getAPIBaseUrl()):ZCRMConfigUtil::getAPIBaseUrl();
-		$this->url=$baseUrl."/crm/".ZCRMConfigUtil::getAPIVersion()."/";
-		$this->url=str_replace(PHP_EOL, '', $this->url);
+	public function constructAPIUrl() {
+		$hitSandbox = ZCRMConfigUtil::getConfigValue('sandbox');
+		$baseUrl = strcasecmp($hitSandbox, 'true') == 0 ? str_replace('www', 'sandbox', ZCRMConfigUtil::getAPIBaseUrl())
+		                                                : ZCRMConfigUtil::getAPIBaseUrl();
+		$this->url = $baseUrl.'/crm/'.ZCRMConfigUtil::getAPIVersion().'/';
+		$this->url = str_replace(PHP_EOL, '', $this->url);
 	}
 
-	private function authenticateRequest()
-	{
-		try{
-			$accessToken= (new ZCRMConfigUtil())->getAccessToken();
-			$this->requestHeaders[APIConstants::AUTHORIZATION]=APIConstants::OAUTH_HEADER_PREFIX.$accessToken;
-		}catch (ZCRMException $ex)
-		{
+	private function authenticateRequest() {
+		try {
+			$accessToken = (new ZCRMConfigUtil())->getAccessToken();
+			$this->requestHeaders[APIConstants::AUTHORIZATION] = APIConstants::OAUTH_HEADER_PREFIX.$accessToken;
+		} catch (ZCRMException $ex) {
 			throw $ex;
 		}
 	}
@@ -71,8 +66,7 @@ class APIRequest
 	 * initiate the request and get the API response
 	 * @return Instance of APIResponse
 	 */
-	public function getAPIResponse()
-	{
+	public function getAPIResponse() {
 		try {
 			$connector=ZohoHTTPConnector::getInstance();
 			$connector->setUrl($this->url);
@@ -82,13 +76,11 @@ class APIRequest
 			$connector->setRequestBody($this->requestBody);
 			$connector->setRequestType($this->requestMethod);
 			$connector->setApiKey($this->apiKey);
-			$response=$connector->fireRequest();
-			$this->response=$response[0];
-			$this->responseInfo=$response[1];
-			return new APIResponse($this->response,$this->responseInfo['http_code']);
-		}
-		catch (ZCRMException $e)
-		{
+			$response = $connector->fireRequest();
+			$this->response = $response[0];
+			$this->responseInfo = $response[1];
+			return new APIResponse($this->response, $this->responseInfo['http_code']);
+		} catch (ZCRMException $e) {
 			throw $e;
 		}
 	}
@@ -97,8 +89,7 @@ class APIRequest
 	 * initiate the request and get the API response
 	 * @return instance of BulkAPIResponse
 	 */
-	public function getBulkAPIResponse()
-	{
+	public function getBulkAPIResponse() {
 		try {
 			$connector=ZohoHTTPConnector::getInstance();
 			$connector->setUrl($this->url);
@@ -110,30 +101,27 @@ class APIRequest
 			$connector->setApiKey($this->apiKey);
 			$connector->setBulkRequest(true);
 			$response=$connector->fireRequest();
-			$this->response=$response[0];
-			$this->responseInfo=$response[1];
-			return new BulkAPIResponse($this->response,$this->responseInfo['http_code']);
-		}
-		catch (ZCRMException $e)
-		{
+			$this->response = $response[0];
+			$this->responseInfo = $response[1];
+			return new BulkAPIResponse($this->response, $this->responseInfo['http_code']);
+		} catch (ZCRMException $e) {
 			throw $e;
 		}
 	}
 
-	public function uploadFile($filePath)
-	{
+	public function uploadFile($filePath) {
 		try {
-			$fileContent=file_get_contents($filePath);
-			$filePathArray=explode('/',$filePath);
-			$fileName=$filePathArray[sizeof($filePathArray)-1];
+			$fileContent = file_get_contents($filePath);
+			$filePathArray = explode('/',$filePath);
+			$fileName = $filePathArray[sizeof($filePathArray)-1];
 			if (function_exists('curl_file_create')) { // php 5.6+
 				$cFile = curl_file_create($filePath);
 			} else { //
 				$cFile = '@' . realpath($filePath);
 			}
-			$post = array('file'=> $cFile);
+			$post = array('file' => $cFile);
 
-			$connector=ZohoHTTPConnector::getInstance();
+			$connector = ZohoHTTPConnector::getInstance();
 			$connector->setUrl($this->url);
 			self::authenticateRequest();
 			$connector->setRequestHeadersMap($this->requestHeaders);
@@ -141,42 +129,35 @@ class APIRequest
 			$connector->setRequestBody($post);
 			$connector->setRequestType($this->requestMethod);
 			$connector->setApiKey($this->apiKey);
-			$response=$connector->fireRequest();
-			$this->response=$response[0];
-			$this->responseInfo=$response[1];
-			return new APIResponse($this->response,$this->responseInfo['http_code']);
-		}
-		catch (ZCRMException $e)
-		{
+			$response = $connector->fireRequest();
+			$this->response = $response[0];
+			$this->responseInfo = $response[1];
+			return new APIResponse($this->response, $this->responseInfo['http_code']);
+		} catch (ZCRMException $e) {
 			throw $e;
 		}
 	}
 
-	public function uploadLinkAsAttachment($linkURL)
-	{
+	public function uploadLinkAsAttachment($linkURL) {
 		try {
-			$post = array('attachmentUrl'=> $linkURL);
-
-			$connector=ZohoHTTPConnector::getInstance();
+			$post = array('attachmentUrl' => $linkURL);
+			$connector = ZohoHTTPConnector::getInstance();
 			$connector->setUrl($this->url);
 			self::authenticateRequest();
 			$connector->setRequestHeadersMap($this->requestHeaders);
 			$connector->setRequestBody($post);
 			$connector->setRequestType($this->requestMethod);
 			$connector->setApiKey($this->apiKey);
-			$response=$connector->fireRequest();
-			$this->response=$response[0];
-			$this->responseInfo=$response[1];
-			return new APIResponse($this->response,$this->responseInfo['http_code']);
-		}
-		catch (ZCRMException $e)
-		{
+			$response = $connector->fireRequest();
+			$this->response = $response[0];
+			$this->responseInfo = $response[1];
+			return new APIResponse($this->response, $this->responseInfo['http_code']);
+		} catch (ZCRMException $e) {
 			throw $e;
 		}
 	}
 
-	public function downloadFile()
-	{
+	public function downloadFile() {
 		try {
 			$connector=ZohoHTTPConnector::getInstance();
 			$connector->setUrl($this->url);
@@ -184,10 +165,9 @@ class APIRequest
 			$connector->setRequestHeadersMap($this->requestHeaders);
 			$connector->setRequestParamsMap($this->requestParams);
 			$connector->setRequestType($this->requestMethod);
-			$response=$connector->downloadFile();
+			$response = $connector->downloadFile();
 			return (new FileAPIResponse())->setFileContent($response[0],$response[1]['http_code']);
-		}catch (ZCRMException $e)
-		{
+		} catch (ZCRMException $e) {
 			throw $e;
 		}
 	}
@@ -196,7 +176,7 @@ class APIRequest
      * Get the request url
      * @return String
      */
-    public function getUrl(){
+    public function getUrl() {
         return $this->url;
     }
 
@@ -204,7 +184,7 @@ class APIRequest
      * Set the request url
      * @param String $url
      */
-    public function setUrl($url){
+    public function setUrl($url) {
         $this->url = $url;
     }
 
@@ -212,7 +192,7 @@ class APIRequest
      * Get the request parameters
      * @return Array
      */
-    public function getRequestParams(){
+    public function getRequestParams() {
         return $this->requestParams;
     }
 
@@ -220,7 +200,7 @@ class APIRequest
      * Set the request parameters
      * @param Array $requestParams
      */
-    public function setRequestParams($requestParams){
+    public function setRequestParams($requestParams) {
         $this->requestParams = $requestParams;
     }
 
@@ -228,7 +208,7 @@ class APIRequest
      * Get the request headers
      * @return Array
      */
-    public function getRequestHeaders(){
+    public function getRequestHeaders() {
         return $this->requestHeaders;
     }
 
@@ -236,7 +216,7 @@ class APIRequest
      * Set the request headers
      * @param Array $requestHeaders
      */
-    public function setRequestHeaders($requestHeaders){
+    public function setRequestHeaders($requestHeaders) {
         $this->requestHeaders = $requestHeaders;
     }
 
@@ -244,7 +224,7 @@ class APIRequest
      * Get the request body
      * @return JSON
      */
-    public function getRequestBody(){
+    public function getRequestBody() {
         return $this->requestBody;
     }
 
@@ -252,7 +232,7 @@ class APIRequest
      * Set the request body
      * @param JSON $requestBody
      */
-    public function setRequestBody($requestBody){
+    public function setRequestBody($requestBody) {
         $this->requestBody = $requestBody;
     }
 
@@ -260,7 +240,7 @@ class APIRequest
      * Get the request method
      * @return String
      */
-    public function getRequestMethod(){
+    public function getRequestMethod() {
         return $this->requestMethod;
     }
 
@@ -268,7 +248,7 @@ class APIRequest
      * Set the request method
      * @param String $requestMethod
      */
-    public function setRequestMethod($requestMethod){
+    public function setRequestMethod($requestMethod) {
         $this->requestMethod = $requestMethod;
     }
 
@@ -276,7 +256,7 @@ class APIRequest
      * Get the API Key used in the input json data(like 'modules', 'data','layouts',..etc)
      * @return String
      */
-    public function getApiKey(){
+    public function getApiKey() {
         return $this->apiKey;
     }
 
@@ -284,7 +264,7 @@ class APIRequest
      *  Set the API Key used in the input json data(like 'modules', 'data','layouts',..etc)
      * @param String $apiKey
      */
-    public function setApiKey($apiKey){
+    public function setApiKey($apiKey) {
         $this->apiKey = $apiKey;
     }
 }

--- a/src/com/zoho/crm/library/api/handler/APIHandler.php
+++ b/src/com/zoho/crm/library/api/handler/APIHandler.php
@@ -1,78 +1,67 @@
 <?php
+
 require_once 'APIHandlerInterface.php';
 
 class APIHandler implements APIHandlerInterface
 {
-
 	protected $requestMethod;
 	protected $urlPath;
-	
 	protected $requestHeaders;
 	protected $requestParams;
 	protected $requestBody;
 	protected $apiKey;
-	
-	
-	public function getRequestMethod()
-	{
+
+	public function getRequestMethod() {
 		return $this->requestMethod;
 	}
-	
-	public function getUrlPath()
-	{
+
+	public function getUrlPath() {
 		return $this->urlPath;
 	}
-	
-	public function getRequestHeaders()
-	{
+
+	public function getRequestHeaders() {
 		return $this->requestHeaders;
 	}
-	
-	public function getRequestBody()
-	{
+
+	public function getRequestBody() {
 		return $this->requestBody;
 	}
-	
-	public function getRequestParams()
-	{
+
+	public function getRequestParams() {
 		return $this->requestParams;
 	}
-	
+
 	public function addParam($key,$value) {
-		if(!isset($this->requestParams[$key]))
-		{
-			$this->requestParams[$key]=array($value);
-		}else{
-			$valArray=$this->requestParams[$key];
+		if (!isset($this->requestParams[$key])) {
+			$this->requestParams[$key] = array($value);
+		} else {
+			$valArray = $this->requestParams[$key];
 			array_push($valArray,$value);
-			$this->requestParams[$key]=$valArray;
+			$this->requestParams[$key] = $valArray;
 		}
 	}
 	public function addHeader($key,$value) {
-		$this->requestHeaders[$key]=$value;
+		$this->requestHeaders[$key] = $value;
 	}
-	
-	public function getRequestHeadersAsMap()
-	{
+
+	public function getRequestHeadersAsMap() {
 		return CommonUtil.convertJSONObjectToHashMap($this->requestHeaders);
 	}
-	
-	public function getRequestParamsAsMap()
-	{
+
+	public function getRequestParamsAsMap() {
 		return CommonUtil.convertJSONObjectToHashMap($this->requestParams);
 	}
-	
-	public static function getEmptyJSONObject()
-	{
+
+	public static function getEmptyJSONObject() {
 		return json_decode('{}');
 	}
-	
+
 
     /**
      *  Set the request method
      * @param String $requestMethod
      */
-    public function setRequestMethod($requestMethod){
+    public function setRequestMethod($requestMethod) {
         $this->requestMethod = $requestMethod;
     }
 
@@ -80,7 +69,7 @@ class APIHandler implements APIHandlerInterface
      * Set the request urlPath
      * @param String $urlPath
      */
-    public function setUrlPath($urlPath){
+    public function setUrlPath($urlPath) {
         $this->urlPath = $urlPath;
     }
 
@@ -88,7 +77,7 @@ class APIHandler implements APIHandlerInterface
      * set the request Headers
      * @param Array $requestHeaders
      */
-    public function setRequestHeaders($requestHeaders){
+    public function setRequestHeaders($requestHeaders) {
         $this->requestHeaders = $requestHeaders;
     }
 
@@ -96,7 +85,7 @@ class APIHandler implements APIHandlerInterface
      * Set the request parameters
      * @param Array $requestParams
      */
-    public function setRequestParams($requestParams){
+    public function setRequestParams($requestParams) {
         $this->requestParams = $requestParams;
     }
 
@@ -104,7 +93,7 @@ class APIHandler implements APIHandlerInterface
      * Set the requestBody
      * @param JSON $requestBody
      */
-    public function setRequestBody($requestBody){
+    public function setRequestBody($requestBody) {
         $this->requestBody = $requestBody;
     }
 
@@ -112,7 +101,7 @@ class APIHandler implements APIHandlerInterface
      * Get the API Key used in the input json data(like 'modules', 'data','layouts',..etc)
      * @return String
      */
-    public function getApiKey(){
+    public function getApiKey() {
         return $this->apiKey;
     }
 
@@ -120,9 +109,7 @@ class APIHandler implements APIHandlerInterface
      * Set the API Key used in the input json data(like 'modules', 'data','layouts',..etc)
      * @param String $apiKey
      */
-    public function setApiKey($apiKey){
+    public function setApiKey($apiKey) {
         $this->apiKey = $apiKey;
     }
-
 }
-?>

--- a/src/com/zoho/crm/library/api/handler/APIHandlerInterface.php
+++ b/src/com/zoho/crm/library/api/handler/APIHandlerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 interface APIHandlerInterface
 {
 	public function getRequestMethod();
@@ -9,4 +10,3 @@ interface APIHandlerInterface
 	public function getRequestHeadersAsMap();
 	public function getRequestParamsAsMap();
 }
-?>

--- a/src/com/zoho/crm/library/api/handler/EntityAPIHandler.php
+++ b/src/com/zoho/crm/library/api/handler/EntityAPIHandler.php
@@ -1,555 +1,465 @@
 <?php
 
 require_once 'APIHandler.php';
-require_once realpath(dirname(__FILE__).'/../../crud/ZCRMInventoryLineItem.php');
-require_once realpath(dirname(__FILE__).'/../../crud/ZCRMRecord.php');
-require_once realpath(dirname(__FILE__).'/../../crud/ZCRMTax.php');
-require_once realpath(dirname(__FILE__).'/../../exception/APIExceptionHandler.php');
-require_once realpath(dirname(__FILE__).'/../../common/APIConstants.php');
-require_once realpath(dirname(__FILE__).'/../APIRequest.php');
-require_once realpath(dirname(__FILE__).'/../../crud/ZCRMPriceBookPricing.php');
-require_once realpath(dirname(__FILE__).'/../../crud/ZCRMEventParticipant.php');
+require_once realpath(__DIR__.'/../../crud/ZCRMInventoryLineItem.php');
+require_once realpath(__DIR__.'/../../crud/ZCRMRecord.php');
+require_once realpath(__DIR__.'/../../crud/ZCRMTax.php');
+require_once realpath(__DIR__.'/../../exception/APIExceptionHandler.php');
+require_once realpath(__DIR__.'/../../common/APIConstants.php');
+require_once realpath(__DIR__.'/../APIRequest.php');
+require_once realpath(__DIR__.'/../../crud/ZCRMPriceBookPricing.php');
+require_once realpath(__DIR__.'/../../crud/ZCRMEventParticipant.php');
 
 class EntityAPIHandler extends APIHandler
 {
-	protected $record=null;
-	
-	private function __construct($zcrmrecord)
-	{
-		$this->record=$zcrmrecord;
+	protected $record = null;
+
+	private function __construct($zcrmrecord) {
+		$this->record = $zcrmrecord;
 	}
-	
-	public static function getInstance($zcrmrecord)
-	{
+
+	public static function getInstance($zcrmrecord) {
 		return new EntityAPIHandler($zcrmrecord);
 	}
-	
-	public function getRecord()
-	{
-		try{
-			$this->requestMethod=APIConstants::REQUEST_METHOD_GET;
-			$this->urlPath=$this->record->getModuleApiName()."/".$this->record->getEntityId();
-			$this->addHeader("Content-Type","application/json");
-			$responseInstance=APIRequest::getInstance($this)->getAPIResponse();
-			$recordDetails=$responseInstance->getResponseJSON()['data'];
+
+	public function getRecord() {
+		try {
+			$this->requestMethod = APIConstants::REQUEST_METHOD_GET;
+			$this->urlPath = $this->record->getModuleApiName().'/'.$this->record->getEntityId();
+			$this->addHeader('Content-Type', 'application/json');
+			$responseInstance = APIRequest::getInstance($this)->getAPIResponse();
+			$recordDetails = $responseInstance->getResponseJSON()['data'];
 			self::setRecordProperties($recordDetails[0]);
 			$responseInstance->setData($this->record);
 			return $responseInstance;
-		}catch (ZCRMException $exception)
-		{
+		} catch (ZCRMException $exception) {
 			APIExceptionHandler::logException($exception);
 			throw $exception;
 		}
 	}
-	
-	public function createRecord()
-	{
-		try{
-			$inputJSON=self::getZCRMRecordAsJSON();
-			$this->requestMethod=APIConstants::REQUEST_METHOD_POST;
-			$this->urlPath=$this->record->getModuleApiName();
-			$this->addHeader("Content-Type","application/json");
-			$this->requestBody=json_encode(array_filter(array("data"=>array($inputJSON))));
-			$responseInstance=APIRequest::getInstance($this)->getAPIResponse();
-			$responseDataArray=$responseInstance->getResponseJSON()['data'];
-			$responseData=$responseDataArray[0];
-			$reponseDetails=$responseData['details'];
+
+	public function createRecord() {
+		try {
+			$inputJSON = self::getZCRMRecordAsJSON();
+			$this->requestMethod = APIConstants::REQUEST_METHOD_POST;
+			$this->urlPath = $this->record->getModuleApiName();
+			$this->addHeader('Content-Type', 'application/json');
+			$this->requestBody = json_encode(array_filter(array('data' => array($inputJSON))));
+			$responseInstance = APIRequest::getInstance($this)->getAPIResponse();
+			$responseDataArray = $responseInstance->getResponseJSON()['data'];
+			$responseData = $responseDataArray[0];
+			$reponseDetails = $responseData['details'];
 			$this->record->setEntityId($reponseDetails['id']);
 			$this->record->setCreatedTime($reponseDetails['Created_Time']);
-			$createdBy=$reponseDetails['Created_By'];
-			$this->record->setCreatedBy(ZCRMUser::getInstance($createdBy['id']+0,$createdBy['name']));
-			
+			$createdBy = $reponseDetails['Created_By'];
+			$this->record->setCreatedBy(ZCRMUser::getInstance((int)$createdBy['id'], $createdBy['name']));
 			$responseInstance->setData($this->record);
-			
 			return $responseInstance;
-		}catch (ZCRMException $exception)
-		{
+		} catch (ZCRMException $exception) {
 			APIExceptionHandler::logException($exception);
 			throw $exception;
 		}
 	}
-	
-	public function updateRecord()
-	{
-		try{
-			$inputJSON=self::getZCRMRecordAsJSON();
-			$this->requestMethod=APIConstants::REQUEST_METHOD_PUT;
-			$this->urlPath=$this->record->getModuleApiName()."/".$this->record->getEntityId();
-			$this->addHeader("Content-Type","application/json");
-			$this->requestBody=json_encode(array_filter(array("data"=>array($inputJSON))));;
-				
-			$responseInstance=APIRequest::getInstance($this)->getAPIResponse();
-				
-			$responseDataArray=$responseInstance->getResponseJSON()['data'];
-			$responseData=$responseDataArray[0];
-			$reponseDetails=$responseData['details'];
+
+	public function updateRecord() {
+		try {
+			$inputJSON = self::getZCRMRecordAsJSON();
+			$this->requestMethod = APIConstants::REQUEST_METHOD_PUT;
+			$this->urlPath = $this->record->getModuleApiName().'/'.$this->record->getEntityId();
+			$this->addHeader('Content-Type', 'application/json');
+			$this->requestBody = json_encode(array_filter(array('data' => array($inputJSON))));
+
+			$responseInstance = APIRequest::getInstance($this)->getAPIResponse();
+
+			$responseDataArray = $responseInstance->getResponseJSON()['data'];
+			$responseData = $responseDataArray[0];
+			$reponseDetails = $responseData['details'];
 			$this->record->setCreatedTime($reponseDetails['Created_Time']);
 			$this->record->setModifiedTime($reponseDetails['Modified_Time']);
-			$createdBy=$reponseDetails['Created_By'];
-			$this->record->setCreatedBy(ZCRMUser::getInstance($createdBy['id']+0,$createdBy['name']));
-			$modifiedBy=$reponseDetails['Modified_By'];
-			$this->record->setModifiedBy(ZCRMUser::getInstance($modifiedBy['id']+0,$modifiedBy['name']));
-			
+			$createdBy = $reponseDetails['Created_By'];
+			$this->record->setCreatedBy(ZCRMUser::getInstance((int)$createdBy['id'], $createdBy['name']));
+			$modifiedBy = $reponseDetails['Modified_By'];
+			$this->record->setModifiedBy(ZCRMUser::getInstance((int)$modifiedBy['id'], $modifiedBy['name']));
+
 			$responseInstance->setData($this->record);
-				
+
 			return $responseInstance;
-		}catch (ZCRMException $exception)
-		{
+		} catch (ZCRMException $exception) {
 			APIExceptionHandler::logException($exception);
 			throw $exception;
 		}
 	}
-	
-	public function deleteRecord()
-	{
-		try{
-			$this->requestMethod=APIConstants::REQUEST_METHOD_DELETE;
-			$this->urlPath=$this->record->getModuleApiName()."/".$this->record->getEntityId();
-			$this->addHeader("Content-Type","application/json");
-	
-			$responseInstance=APIRequest::getInstance($this)->getAPIResponse();
-	
+
+	public function deleteRecord() {
+		try {
+			$this->requestMethod = APIConstants::REQUEST_METHOD_DELETE;
+			$this->urlPath = $this->record->getModuleApiName().'/'.$this->record->getEntityId();
+			$this->addHeader('Content-Type', 'application/json');
+
+			$responseInstance = APIRequest::getInstance($this)->getAPIResponse();
+
 			return $responseInstance;
-		}catch (ZCRMException $exception)
-		{
+		} catch (ZCRMException $exception) {
 			APIExceptionHandler::logException($exception);
 			throw $exception;
 		}
 	}
-	
-	public function convertRecord($potentialRecord, $assignToUser)
-	{
-		try{
-			$this->requestMethod=APIConstants::REQUEST_METHOD_POST;
-			$this->urlPath=$this->record->getModuleApiName()."/".$this->record->getEntityId()."/actions/convert";
-			$this->addHeader("Content-Type","application/json");
-			
-			$dataObject=array();
-			if($assignToUser!=null)
-			{
-				$dataObject['assign_to']=$assignToUser->getId();
+
+	public function convertRecord($potentialRecord, $assignToUser) {
+		try {
+			$this->requestMethod = APIConstants::REQUEST_METHOD_POST;
+			$this->urlPath = $this->record->getModuleApiName().'/'.$this->record->getEntityId().'/actions/convert';
+			$this->addHeader('Content-Type', 'application/json');
+
+			$dataObject = array();
+			if ($assignToUser != null) {
+				$dataObject['assign_to'] = $assignToUser->getId();
 			}
-			if($potentialRecord!=null)
-			{
-				$dataObject['Deals']=self::getInstance($potentialRecord)->getZCRMRecordAsJSON();
+			if ($potentialRecord != null) {
+				$dataObject['Deals'] = self::getInstance($potentialRecord)->getZCRMRecordAsJSON();
 			}
-			if(sizeof($dataObject)>0)
-			{
-				$dataArray=json_encode(array(APIConstants::DATA=>array(array_filter($dataObject))));
-			}else
-			{
-				$dataArray=json_encode(array(APIConstants::DATA=>array(new ArrayObject())));
+			if (sizeof($dataObject) > 0) {
+				$dataArray = json_encode(array(APIConstants::DATA => array(array_filter($dataObject))));
+			} else {
+				$dataArray = json_encode(array(APIConstants::DATA => array(new ArrayObject())));
 			}
-			$this->requestBody=$dataArray;
-			
-			$responseInstance=APIRequest::getInstance($this)->getAPIResponse();
-			
-			$responseJSON=$responseInstance->getResponseJSON();
-			
-			
+			$this->requestBody = $dataArray;
+
+			$responseInstance = APIRequest::getInstance($this)->getAPIResponse();
+
+			$responseJSON = $responseInstance->getResponseJSON();
+
 			//Process Response JSON
 			$convertedIdsJSON = $responseJSON[APIConstants::DATA][0];
 			$convertedIds = array();
-			$convertedIds[APIConstants::CONTACTS]=isset($convertedIdsJSON[APIConstants::CONTACTS])?$convertedIdsJSON[APIConstants::CONTACTS]+0:null;
-			if(isset($convertedIdsJSON[APIConstants::ACCOUNTS]) && $convertedIdsJSON[APIConstants::ACCOUNTS]!=null)
-			{
-				$convertedIds[APIConstants::ACCOUNTS]=$convertedIdsJSON[APIConstants::ACCOUNTS]+0;
+			$convertedIds[APIConstants::CONTACTS] = isset($convertedIdsJSON[APIConstants::CONTACTS])
+			                                      ? $convertedIdsJSON[APIConstants::CONTACTS] + 0
+			                                      : null;
+			if (isset($convertedIdsJSON[APIConstants::ACCOUNTS]) && $convertedIdsJSON[APIConstants::ACCOUNTS] != null) {
+				$convertedIds[APIConstants::ACCOUNTS] = $convertedIdsJSON[APIConstants::ACCOUNTS] + 0;
 			}
-			if(isset($convertedIdsJSON[APIConstants::DEALS]) && $convertedIdsJSON[APIConstants::DEALS]!=null)
-			{
-				$convertedIds[APIConstants::DEALS]=$convertedIdsJSON[APIConstants::DEALS]+0;
+			if (isset($convertedIdsJSON[APIConstants::DEALS]) && $convertedIdsJSON[APIConstants::DEALS] != null) {
+				$convertedIds[APIConstants::DEALS] = $convertedIdsJSON[APIConstants::DEALS] + 0;
 			}
-			
+
 			return $convertedIds;
-		}catch (ZCRMException $exception)
-		{
+		} catch (ZCRMException $exception) {
 			APIExceptionHandler::logException($exception);
 			throw $exception;
 		}
 	}
-	
-	public function uploadPhoto($filePath)
-	{
-		try{
-			$fileContent=file_get_contents($filePath);
-			$filePathArray=explode('/',$filePath);
-			$fileName=$filePathArray[sizeof($filePathArray)-1];
+
+	public function uploadPhoto($filePath) {
+		try {
+			$fileContent = file_get_contents($filePath);
+			$filePathArray = explode('/', $filePath);
+			$fileName = $filePathArray[sizeof($filePathArray)-1];
 			if (function_exists('curl_file_create')) { // php 5.6+
 				$cFile = curl_file_create($filePath);
 			} else { //
-				$cFile = '@' . realpath($filePath);
+				$cFile = '@'.realpath($filePath);
 			}
-			$post = array('file'=> $cFile);
-			
-			$this->requestMethod=APIConstants::REQUEST_METHOD_POST;
-			$this->urlPath=$this->record->getModuleApiName()."/".$this->record->getEntityId()."/photo";
-			$this->requestBody=$post;
-			
+			$post = array('file' => $cFile);
+
+			$this->requestMethod = APIConstants::REQUEST_METHOD_POST;
+			$this->urlPath = $this->record->getModuleApiName().'/'.$this->record->getEntityId().'/photo';
+			$this->requestBody = $post;
+
 			$responseInstance=APIRequest::getInstance($this)->getAPIResponse();
-			
+
 			return $responseInstance;
-			
-		}catch (ZCRMException $exception)
-		{
+		} catch (ZCRMException $exception) {
 			APIExceptionHandler::logException($exception);
 			throw $exception;
 		}
 	}
-	public function downloadPhoto()
-	{
-		try{
-			$this->requestMethod=APIConstants::REQUEST_METHOD_GET;
-			$this->urlPath=$this->record->getModuleApiName()."/".$this->record->getEntityId()."/photo";
-				
+
+	public function downloadPhoto() {
+		try {
+			$this->requestMethod = APIConstants::REQUEST_METHOD_GET;
+			$this->urlPath = $this->record->getModuleApiName().'/'.$this->record->getEntityId().'/photo';
+
 			return APIRequest::getInstance($this)->downloadFile();
-		}catch (ZCRMException $exception)
-		{
+		} catch (ZCRMException $exception) {
 			APIExceptionHandler::logException($exception);
 			throw $exception;
 		}
 	}
-	
-	public function deletePhoto()
-	{
-		try{
-			$this->requestMethod=APIConstants::REQUEST_METHOD_DELETE;
-			$this->urlPath=$this->record->getModuleApiName()."/".$this->record->getEntityId()."/photo";
-	
+
+	public function deletePhoto() {
+		try {
+			$this->requestMethod = APIConstants::REQUEST_METHOD_DELETE;
+			$this->urlPath = $this->record->getModuleApiName().'/'.$this->record->getEntityId().'/photo';
+
 			return APIRequest::getInstance($this)->getAPIResponse();
-		}catch (ZCRMException $exception)
-		{
+		} catch (ZCRMException $exception) {
 			APIExceptionHandler::logException($exception);
 			throw $exception;
 		}
 	}
-	
-	function getZCRMRecordAsJSON()
-	{
-		$recordJSON=array();
-		$apiNameVsValues=$this->record->getData();
-		if($this->record->getOwner()!=null)
-		{
+
+	function getZCRMRecordAsJSON() {
+		$recordJSON = array();
+		$apiNameVsValues = $this->record->getData();
+		if ($this->record->getOwner() != null) {
 			$recordJSON["Owner"]="".$this->record->getOwner()->getId();
 		}
-		if($this->record->getLayout()!=null)
-		{
+		if ($this->record->getLayout()!=null) {
 			$recordJSON["Layout"]="".$this->record->getLayout()->getId();
 		}
-		foreach ($apiNameVsValues as $key=>$value)
-		{
-			if($value instanceof ZCRMRecord)
-			{
-				$value = "".$value->getEntityId();
+		foreach ($apiNameVsValues as $key => $value) {
+			if ($value instanceof ZCRMRecord) {
+				$value = (string)$value->getEntityId();
+			} elseif ($value instanceof ZCRMUser) {
+				$value = (string)$value->getId();
 			}
-			else if($value instanceof ZCRMUser)
-			{
-				$value = "". $value->getId();
-			}
-			$recordJSON[$key]=$value;
+			$recordJSON[$key] = $value;
 		}
-		if(sizeof($this->record->getLineItems())>0)
-		{
-			$recordJSON["Product_Details"]=self::getLineItemJSON($this->record->getLineItems());
+		if (sizeof($this->record->getLineItems()) > 0) {
+			$recordJSON['Product_Details'] = self::getLineItemJSON($this->record->getLineItems());
 		}
-		if(sizeof($this->record->getParticipants())>0)
-		{
-			$recordJSON["Participants"]=self::getParticipantsAsJSONArray();
+		if (sizeof($this->record->getParticipants()) > 0) {
+			$recordJSON['Participants'] = self::getParticipantsAsJSONArray();
 		}
-		if(sizeof($this->record->getPriceDetails())>0)
-		{
-			$recordJSON["Pricing_Details"]=self::getPriceDetailsAsJSONArray();
+		if (sizeof($this->record->getPriceDetails()) > 0) {
+			$recordJSON['Pricing_Details'] = self::getPriceDetailsAsJSONArray();
 		}
-		if(sizeof($this->record->getTaxList())>0)
-		{
-			$recordJSON["Tax"]=self::getTaxListAsJSON();
+		if (sizeof($this->record->getTaxList()) > 0) {
+			$recordJSON['Tax'] = self::getTaxListAsJSON();
 		}
 		return array_filter($recordJSON);
 	}
-	
-	public function getTaxListAsJSON()
-	{
+
+	public function getTaxListAsJSON() {
 		$taxes = array();
 		$taxList = $this->record->getTaxList();
-		foreach ($taxList as $taxIns)
-		{
-			array_push($taxes,$taxIns->getTaxName());
+		foreach ($taxList as $taxIns) {
+			array_push($taxes, $taxIns->getTaxName());
 		}
-		return taxes;
+		return $taxes;
 	}
-	public function getPriceDetailsAsJSONArray()
-	{
+
+	public function getPriceDetailsAsJSONArray() {
 		$priceDetailsArr = array();
 		$priceDetailsList = $this->record->getPriceDetails();
-		foreach ($priceDetailsList as $priceDetailIns)
-		{
+		foreach ($priceDetailsList as $priceDetailIns) {
 			array_push($priceDetailsArr,self::getZCRMPriceDetailAsJSON($priceDetailIns));
 		}
 		return $priceDetailsArr;
 	}
-	public function getZCRMPriceDetailAsJSON(ZCRMPriceBookPricing $priceDetailIns)
-	{
+
+	public function getZCRMPriceDetailAsJSON(ZCRMPriceBookPricing $priceDetailIns) {
 		$priceDetailJSON = array();
-		if ($priceDetailIns->getId() != null)
-		{
-			$priceDetailJSON["id"]=$priceDetailIns->getId();
+		if ($priceDetailIns->getId() != null) {
+			$priceDetailJSON['id'] = $priceDetailIns->getId();
 		}
-		$priceDetailJSON["discount"]=$priceDetailIns->getDiscount();
-		$priceDetailJSON["to_range"]=$priceDetailIns->getToRange();
-		$priceDetailJSON["from_range"]=$priceDetailIns->getFromRange();
+		$priceDetailJSON['discount']   = $priceDetailIns->getDiscount();
+		$priceDetailJSON['to_range']   = $priceDetailIns->getToRange();
+		$priceDetailJSON['from_range'] = $priceDetailIns->getFromRange();
 		return $priceDetailJSON;
 	}
-	
-	public function getParticipantsAsJSONArray()
-	{
+
+	public function getParticipantsAsJSONArray() {
 		$participantsArr = array();
 		$participantsList = $this->record->getParticipants();
-		foreach($participantsList as $participantIns)
-		{
-			array_push($participantsArr,self::getZCRMParticipantAsJSON($participantIns));
+		foreach($participantsList as $participantIns) {
+			array_push($participantsArr, self::getZCRMParticipantAsJSON($participantIns));
 		}
 		return $participantsArr;
 	}
-	
-	public function getZCRMParticipantAsJSON(ZCRMEventParticipant $participantIns)
-	{
+
+	public function getZCRMParticipantAsJSON(ZCRMEventParticipant $participantIns) {
 		$participantJSON = array();
-		$participantJSON["participant"]= "".$participantIns->getId();
-		$participantJSON["type"]="".$participantIns->getType();
-		$participantJSON["name"]="".$participantIns->getName();
-		$participantJSON["Email"]="".$participantIns->getEmail();
-		$participantJSON["invited"]=(boolean)$participantIns->isInvited();
-		$participantJSON["status"]="".$participantIns->getStatus();
-		
+		$participantJSON['participant'] = (string)$participantIns->getId();
+		$participantJSON['type'] = (string)$participantIns->getType();
+		$participantJSON['name'] = (string)$participantIns->getName();
+		$participantJSON['Email'] = (string)$participantIns->getEmail();
+		$participantJSON['invited'] = (boolean)$participantIns->isInvited();
+		$participantJSON['status'] = (string)$participantIns->getStatus();
+
 		return $participantJSON;
 	}
-	
-	public function getLineItemJSON($lineItemsArray)
-	{
-		$lineItemsAsJSONArray=array();
-		foreach ($lineItemsArray as $lineItem)
-		{
-			$lineItemData=array();
-			if($lineItem->getQuantity()==null)
-			{
-				throw new ZCRMException("Mandatory Field 'quantity' is missing.",APIConstants::RESPONSECODE_BAD_REQUEST);
+
+	public function getLineItemJSON($lineItemsArray) {
+		$lineItemsAsJSONArray = array();
+		foreach ($lineItemsArray as $lineItem) {
+			$lineItemData = array();
+			if ($lineItem->getQuantity() == null) {
+				throw new ZCRMException("Mandatory Field 'quantity' is missing.", APIConstants::RESPONSECODE_BAD_REQUEST);
 			}
-			if($lineItem->getId()!=null)
-			{
-				$lineItemData["id"]="".$lineItem->getId();
+			if ($lineItem->getId() != null) {
+				$lineItemData['id'] = (string)$lineItem->getId();
 			}
-			if($lineItem->getProduct()!=null)
-			{
-				$lineItemData["product"]="".$lineItem->getProduct()->getEntityId();
+			if ($lineItem->getProduct() != null) {
+				$lineItemData['product'] = (string)$lineItem->getProduct()->getEntityId();
 			}
-			if($lineItem->getDescription()!=null)
-			{
-				$lineItemData["product_description"]=$lineItem->getDescription();
+			if ($lineItem->getDescription() != null) {
+				$lineItemData['product_description'] = $lineItem->getDescription();
 			}
-			if($lineItem->getListPrice()!=null)
-			{
-				$lineItemData["list_price"]=$lineItem->getListPrice();
+			if ($lineItem->getListPrice() != null) {
+				$lineItemData['list_price'] = $lineItem->getListPrice();
 			}
-			$lineItemData["quantity"]=$lineItem->getQuantity();
+			$lineItemData['quantity'] = $lineItem->getQuantity();
 			/*
 			 *  Either discount percentage can be 0 or discount value can be 0. So if percentage is 0, set value and vice versa.
 			 *	If the intended discount is 0, then both percent and value will be 0. Hence setting either of this to 0, will be enough.
 			*/
-			if ($lineItem->getDiscountPercentage() == null)
-			{
-				$lineItemData["Discount"]=$lineItem->getDiscount();
-			}
-			else
-			{
-				$lineItemData["Discount"]=$lineItem->getDiscountPercentage()."%";
-			}
-			$lineTaxes=$lineItem->getLineTax();
-			$lineTaxArray=array();
-			foreach ($lineTaxes as $lineTaxInstance)
-			{
-				$tax=array();
-				$tax['name']=$lineTaxInstance->getTaxName();
-				$tax['value']=$lineTaxInstance->getValue();
-				$tax['percentage']=$lineTaxInstance->getPercentage();
+			$lineItemData['Discount'] = ($lineItem->getDiscountPercentage() == null)
+			                          ? $lineItem->getDiscount()
+				                      : $lineItem->getDiscountPercentage().'%';
+			$lineTaxes = $lineItem->getLineTax();
+			$lineTaxArray = array();
+			foreach ($lineTaxes as $lineTaxInstance) {
+				$tax = array();
+				$tax['name'] = $lineTaxInstance->getTaxName();
+				$tax['value'] = $lineTaxInstance->getValue();
+				$tax['percentage'] = $lineTaxInstance->getPercentage();
 				array_push($lineTaxArray,$tax);
 			}
-			$lineItemData['line_tax']=$lineTaxArray;
-			
-			array_push($lineItemsAsJSONArray,array_filter($lineItemData));
+			$lineItemData['line_tax'] = $lineTaxArray;
+
+			array_push($lineItemsAsJSONArray, array_filter($lineItemData));
 		}
 		return array_filter($lineItemsAsJSONArray);
 	}
-	
-	public function setRecordProperties($recordDetails)
-	{
-		foreach($recordDetails as $key=>$value)
-		{
-			if("id"==$key)
-			{
-				$this->record->setEntityId($value+0);
-			}
-			else if("Product_Details"==$key)
-			{
-				$this->setInventoryLineItems($value);
-			}
-			else if("Participants"==$key)
-			{
-				$this->setParticipants($value);
-			}
-			else if ("Pricing_Details"==$key)
-			{
-				$this->setPriceDetails($value);
-			}
-			else if("Created_By"==$key)
-			{
-				$createdBy = ZCRMUser::getInstance($value["id"], $value["name"]);
-				$this->record->setCreatedBy($createdBy);
-			}
-			else if("Modified_By"==$key)
-			{
-				$modifiedBy = ZCRMUser::getInstance($value["id"], $value["name"]);
-				$this->record->setModifiedBy($modifiedBy);
-			}
-			else if("Created_Time"==$key)
-			{
-				$this->record->setCreatedTime("".$value);
-			}
-			else if("Modified_Time"==$key)
-			{
-				$this->record->setModifiedTime("".$value);
-			}
-			else if("Last_Activity_Time"==$key)
-			{
-				$this->record->setLastActivityTime("".$value);
-			}
-			else if("Owner"==$key)
-			{
-				$owner =ZCRMUser::getInstance($value["id"], $value["name"]);
-				$this->record->setOwner($owner);
-			}
-			else if("Layout"==$key)
-			{
-				$layout = null;
-				if($value!=null)
-				{
-					$layout = ZCRMLayout::getInstance($value["id"]+0);
-					$layout->setName($value["name"]);
-				}
-				$this->record->setLayout($layout);
-			}
-			else if("Handler"==$key && $value!=null)
-			{
-				$handler = ZCRMUser::getInstance($value["id"], $value["name"]);
-				$this->record->setFieldValue($key, $handler);
-			}
-			else if ("Tax"===$key && is_array($value))
-			{
-				foreach ($value as $taxName)
-				{
-					$taxIns=ZCRMTax::getInstance($taxName);
-					$this->record->addTax($taxIns);
-				}
-			}
-			else if(substr($key,0,1)=="$")
-			{
-				$this->record->setProperty(str_replace('$','',$key), $value);
-			}
-			else if(is_array($value))
-			{
-				if(isset($value["id"]))
-				{
-					$lookupRecord = ZCRMRecord::getInstance($key, isset($value["id"])?$value["id"]+0:0);
-					$lookupRecord->setLookupLabel(isset($value["name"])?$value["name"]:null);
-					$this->record->setFieldValue($key, $lookupRecord);
-				}
-				else
-				{
-					$this->record->setFieldValue($key, $value);
-				}
-				
-			}
-			else
-			{
-				$this->record->setFieldValue($key, $value);
-			}
+
+	public function setRecordProperties($recordDetails) {
+		foreach ($recordDetails as $key => $value) {
+    		switch ($key) {
+			    case 'id':
+				    $this->record->setEntityId((int)$value);
+				    break;
+                case 'Product_Details':
+    				$this->setInventoryLineItems($value);
+    				break;
+                case 'Participants':
+    				$this->setParticipants($value);
+    				break;
+                case 'Pricing_Details':
+    				$this->setPriceDetails($value);
+    				break;
+                case 'Created_By':
+    				$createdBy = ZCRMUser::getInstance($value['id'], $value['name']);
+    				$this->record->setCreatedBy($createdBy);
+    				break;
+                case 'Modified_By':
+				    $modifiedBy = ZCRMUser::getInstance($value['id'], $value['name']);
+                    $this->record->setModifiedBy($modifiedBy);
+                    break;
+                case 'Created_Time':
+				    $this->record->setCreatedTime((string)$value);
+				    break;
+                case 'Modified_Time'
+    				$this->record->setModifiedTime((string)$value);
+    				break;
+                case 'Last_Activity_Time':
+				    $this->record->setLastActivityTime((string)$value);
+				    break;
+                case 'Owner':
+    				$owner =ZCRMUser::getInstance($value['id'], $value['name']);
+                    $this->record->setOwner($owner);
+                    break;
+                case 'Layout':
+    				$layout = null;
+                    if ($value != null) {
+					    $layout = ZCRMLayout::getInstance($value['id'] + 0);
+                        $layout->setName($value['name']);
+				    }
+                    $this->record->setLayout($layout);
+                    break;
+                case 'Handler':
+                    if ($value != null) {
+                        $handler = ZCRMUser::getInstance($value['id'], $value['name']);
+                        $this->record->setFieldValue($key, $handler);
+			        }
+			        break;
+                case 'Tax':
+                    if (is_array($value)) {
+        				foreach ($value as $taxName) {
+        					$taxIns = ZCRMTax::getInstance($taxName);
+        					$this->record->addTax($taxIns);
+        				}
+                    }
+                    break;
+                default:
+                    if (strpos($key, '$') === 0) {
+        				$this->record->setProperty(str_replace('$', '', $key), $value);
+        			} elseif (is_array($value)) {
+        				if (isset($value['id'])) {
+        					$lookupRecord = ZCRMRecord::getInstance($key, isset($value['id']) ? (int)$value['id'] : 0);
+        					$lookupRecord->setLookupLabel(isset($value['name']) ? $value["name"] : null);
+        					$this->record->setFieldValue($key, $lookupRecord);
+        				} else {
+        					$this->record->setFieldValue($key, $value);
+        				}
+        			} else {
+        				$this->record->setFieldValue($key, $value);
+        			}
+            }
 		}
 	}
-	
-	private function setParticipants($participants)
-	{
-		foreach ($participants as $participantDetail)
-		{
+
+	private function setParticipants($participants) {
+		foreach ($participants as $participantDetail) {
 			$this->record->addParticipant(self::getZCRMParticipant($participantDetail));
 		}
 	}
-	
-	
-	private function setPriceDetails($priceDetails)
-	{
-		foreach($priceDetails as $priceDetail)
-		{
+
+
+	private function setPriceDetails($priceDetails) {
+		foreach($priceDetails as $priceDetail) {
 			$this->record->addPriceDetail(self::getZCRMPriceDetail($priceDetail));
 		}
 	}
-	
-	public function getZCRMParticipant($participantDetail)
-	{
-		$participant = ZCRMEventParticipant::getInstance($participantDetail['type'],$participantDetail['participant']+0);
-		$participant->setName($participantDetail["name"]);
-		$participant->setEmail($participantDetail["Email"]);
-		$participant->setInvited((boolean)$participantDetail["invited"]);
-		$participant->setStatus($participantDetail["status"]);
-		
+
+	public function getZCRMParticipant($participantDetail) {
+		$participant = ZCRMEventParticipant::getInstance($participantDetail['type'], (int)$participantDetail['participant']);
+		$participant->setName($participantDetail['name']);
+		$participant->setEmail($participantDetail['Email']);
+		$participant->setInvited((boolean)$participantDetail['invited']);
+		$participant->setStatus($participantDetail['status']);
 		return $participant;
 	}
-	
-	public function getZCRMPriceDetail($priceDetails)
-	{
-		$priceDetailIns = ZCRMPriceBookPricing::getInstance($priceDetails["id"]+0);
-		$priceDetailIns->setDiscount((double)$priceDetails["discount"]);
-		$priceDetailIns->setToRange((double)$priceDetails["to_range"]);
-		$priceDetailIns->setFromRange((double)$priceDetails["from_range"]);
-	
+
+	public function getZCRMPriceDetail($priceDetails) {
+		$priceDetailIns = ZCRMPriceBookPricing::getInstance((int)$priceDetails['id']);
+		$priceDetailIns->setDiscount((double)$priceDetails['discount']);
+		$priceDetailIns->setToRange((double)$priceDetails['to_range']);
+		$priceDetailIns->setFromRange((double)$priceDetails['from_range']);
 		return $priceDetailIns;
 	}
-		
-	public function setInventoryLineItems($lineItems)
-	{
-		foreach ($lineItems as $lineItem)
-		{
+
+	public function setInventoryLineItems($lineItems) {
+		foreach ($lineItems as $lineItem) {
 			$this->record->addLineItem(self::getZCRMLineItemInstance($lineItem));
 		}
 	}
-	
-	public function getZCRMLineItemInstance($lineItemDetails)
-	{
-		$productDetails = $lineItemDetails["product"];
-		$lineItemId = $lineItemDetails["id"]+0;
+
+	public function getZCRMLineItemInstance($lineItemDetails) {
+		$productDetails = $lineItemDetails['product'];
+		$lineItemId = (int)$lineItemDetails['id'];
 		$lineItemInstance = ZCRMInventoryLineItem::getInstance($lineItemId);
-		$product = ZCRMRecord::getInstance("Products", $productDetails["id"]+0);
-		$product->setLookupLabel($productDetails["name"]);
-		if(isset($productDetails['Product_Code']))
-		{
+		$product = ZCRMRecord::getInstance('Products', (int)$productDetails['id']);
+		$product->setLookupLabel($productDetails['name']);
+		if (isset($productDetails['Product_Code'])) {
 			$product->setFieldValue('Product_Code', $productDetails['Product_Code']);
 		}
 		$lineItemInstance->setProduct($product);
-		$lineItemInstance->setDescription($lineItemDetails["product_description"]);
-		$lineItemInstance->setQuantity($lineItemDetails["quantity"]+0);
-		$lineItemInstance->setListPrice($lineItemDetails["list_price"]+0);
-		$lineItemInstance->setTotal($lineItemDetails["total"]+0);
-		$lineItemInstance->setDiscount($lineItemDetails["Discount"]+0);
-		$lineItemInstance->setTotalAfterDiscount($lineItemDetails["total_after_discount"]+0);
-		$lineItemInstance->setTaxAmount($lineItemDetails["Tax"]+0);
-		$lineTaxes = $lineItemDetails["line_tax"];
-		foreach($lineTaxes as $lineTax)
-		{
-			$taxInstance=ZCRMTax::getInstance($lineTax["name"]);
+		$lineItemInstance->setDescription($lineItemDetails['product_description']);
+		$lineItemInstance->setQuantity((int)$lineItemDetails['quantity']);
+		$lineItemInstance->setListPrice((int)$lineItemDetails['list_price']);
+		$lineItemInstance->setTotal((int)$lineItemDetails['total']);
+		$lineItemInstance->setDiscount((int)$lineItemDetails['Discount']);
+		$lineItemInstance->setTotalAfterDiscount((int)$lineItemDetails['total_after_discount']);
+		$lineItemInstance->setTaxAmount((int)$lineItemDetails['Tax']);
+		$lineTaxes = $lineItemDetails['line_tax'];
+		foreach ($lineTaxes as $lineTax) {
+			$taxInstance = ZCRMTax::getInstance($lineTax['name']);
 			$taxInstance->setPercentage($lineTax['percentage']);
-			$taxInstance->setValue($lineTax['value']+0);
+			$taxInstance->setValue((int)$lineTax['value']);
 			$lineItemInstance->addLineTax($taxInstance);
 		}
-		$lineItemInstance->setNetTotal($lineItemDetails["net_total"]+0);
-		
+		$lineItemInstance->setNetTotal((int)$lineItemDetails['net_total']);
 		return $lineItemInstance;
 	}
 }
-?>

--- a/src/com/zoho/crm/library/api/handler/MassEntityAPIHandler.php
+++ b/src/com/zoho/crm/library/api/handler/MassEntityAPIHandler.php
@@ -1,22 +1,24 @@
 <?php
-require_once realpath(dirname(__FILE__).'/../../crud/ZCRMRecord.php');
-require_once realpath(dirname(__FILE__).'/../../crud/ZCRMTrashRecord.php');
+
+require_once realpath(__DIR__.'/../../crud/ZCRMRecord.php');
+require_once realpath(__DIR__.'/../../crud/ZCRMTrashRecord.php');
 require_once 'EntityAPIHandler.php';
 require_once 'APIHandler.php';
 
 class MassEntityAPIHandler extends APIHandler
 {
 	private $module=null;
-	
+
 	public function __construct($moduleInstance)
 	{
 		$this->module=$moduleInstance;
 	}
-	
+
 	public static function getInstance($moduleInstance)
 	{
 		return new MassEntityAPIHandler($moduleInstance);
 	}
+
 	public function createRecords($records)
 	{
 		if(sizeof($records) > 100)
@@ -42,7 +44,7 @@ class MassEntityAPIHandler extends APIHandler
 			}
 			$requestBodyObj["data"]=$dataArray;
 			$this->requestBody = $requestBodyObj;
-			
+
 			//Fire Request
 			$bulkAPIResponse = APIRequest::getInstance($this)->getBulkAPIResponse();
 			$createdRecords=array();
@@ -71,7 +73,7 @@ class MassEntityAPIHandler extends APIHandler
 			throw $e;
 		}
 	}
-	
+
 	public function upsertRecords($records)
 	{
 		if(sizeof($records) > 100)
@@ -95,7 +97,7 @@ class MassEntityAPIHandler extends APIHandler
 			}
 			$requestBodyObj["data"]=$dataArray;
 			$this->requestBody = $requestBodyObj;
-				
+
 			//Fire Request
 			$bulkAPIResponse = APIRequest::getInstance($this)->getBulkAPIResponse();
 			$upsertRecords=array();
@@ -124,7 +126,7 @@ class MassEntityAPIHandler extends APIHandler
 			throw $e;
 		}
 	}
-	
+
 	public function updateRecords($records)
 	{
 		if(sizeof($records) > 100)
@@ -148,7 +150,7 @@ class MassEntityAPIHandler extends APIHandler
 			}
 			$requestBodyObj["data"]=$dataArray;
 			$this->requestBody = $requestBodyObj;
-	
+
 			//Fire Request
 			$bulkAPIResponse = APIRequest::getInstance($this)->getBulkAPIResponse();
 			$upsertRecords=array();
@@ -177,7 +179,7 @@ class MassEntityAPIHandler extends APIHandler
 			throw $e;
 		}
 		}
-	
+
 	public function deleteRecords($entityIds)
 	{
 		if(sizeof($entityIds) > 100)
@@ -190,11 +192,11 @@ class MassEntityAPIHandler extends APIHandler
 			$this->requestMethod=APIConstants::REQUEST_METHOD_DELETE;
 			$this->addHeader("Content-Type","application/json");
 			$this->addParam("ids", implode(",", $entityIds));//converts array to string with specified seperator
-			
+
 			//Fire Request
 			$bulkAPIResponse = APIRequest::getInstance($this)->getBulkAPIResponse();
 			$responses=$bulkAPIResponse->getEntityResponses();
-				
+
 			foreach ($responses as $entityResIns)
 			{
 				$responseData = $entityResIns->getResponseJSON();
@@ -209,21 +211,21 @@ class MassEntityAPIHandler extends APIHandler
 			throw $exception;
 		}
 	}
-	public function getAllDeletedRecords() 
+	public function getAllDeletedRecords()
 	{
 		return self::getDeletedRecords("all");
 	}
-	
+
 	public function getRecycleBinRecords()
 	{
 		return self::getDeletedRecords("recycle");
 	}
-	
+
 	public function getPermanentlyDeletedRecords()
 	{
 		return self::getDeletedRecords("permanent");
 	}
-	
+
 	private function getDeletedRecords($type)
 	{
 		try
@@ -232,7 +234,7 @@ class MassEntityAPIHandler extends APIHandler
 			$this->requestMethod=APIConstants::REQUEST_METHOD_GET;
 			$this->addHeader("Content-Type","application/json");
 			$this->addParam("type",$type);
-			
+
 			$responseInstance=APIRequest::getInstance($this)->getBulkAPIResponse();
 			$responseJSON=$responseInstance->getResponseJSON();
 			$trashRecords=$responseJSON["data"];
@@ -243,9 +245,9 @@ class MassEntityAPIHandler extends APIHandler
 				self::setTrashRecordProperties($trashRecordInstance,$trashRecord);
 				array_push($trashRecordList,$trashRecordInstance);
 			}
-			
+
 			$responseInstance->setData($trashRecordList);
-				
+
 			return $responseInstance;
 		}
 		catch (ZCRMException $exception)
@@ -274,7 +276,7 @@ class MassEntityAPIHandler extends APIHandler
 			$trashRecordInstance->setDeletedBy($deletedBy_User);
 		}
 		$trashRecordInstance->setDeletedTime($recordProperties['deleted_time']);
-		
+
 	}
 	public function getRecords($cvId, $sortByField, $sortOrder, $page,$perPage)
 	{
@@ -296,7 +298,7 @@ class MassEntityAPIHandler extends APIHandler
 			}
 			$this->addParam("page",$page+0);
 			$this->addParam("per_page",$perPage+0);
-			
+
 			$responseInstance=APIRequest::getInstance($this)->getBulkAPIResponse();
 			$responseJSON=$responseInstance->getResponseJSON();
 			$records=$responseJSON["data"];
@@ -307,9 +309,9 @@ class MassEntityAPIHandler extends APIHandler
 				EntityAPIHandler::getInstance($recordInstance)->setRecordProperties($record);
 				array_push($recordsList,$recordInstance);
 			}
-				
+
 			$responseInstance->setData($recordsList);
-			
+
 			return $responseInstance;
 		}catch (ZCRMException $exception)
 		{
@@ -317,7 +319,7 @@ class MassEntityAPIHandler extends APIHandler
 			throw $exception;
 		}
 	}
-	
+
 	public function searchRecords($searchWord,$page,$perPage)
 	{
 		try{
@@ -337,9 +339,9 @@ class MassEntityAPIHandler extends APIHandler
 				EntityAPIHandler::getInstance($recordInstance)->setRecordProperties($record);
 				array_push($recordsList,$recordInstance);
 			}
-		
+
 			$responseInstance->setData($recordsList);
-				
+
 			return $responseInstance;
 		}catch (ZCRMException $exception)
 		{
@@ -347,7 +349,7 @@ class MassEntityAPIHandler extends APIHandler
 			throw $exception;
 		}
 	}
-	
+
 	public function massUpdateRecords($idList,$apiName,$value)
 	{
 		if(sizeof($idList)>100)
@@ -362,7 +364,7 @@ class MassEntityAPIHandler extends APIHandler
 			$this->requestBody=$inputJSON;
 			$this->apiKey='data';
 			$bulkAPIResponse=APIRequest::getInstance($this)->getBulkAPIResponse();
-			
+
 			$updatedRecords=array();
 			$responses=$bulkAPIResponse->getEntityResponses();
 			$size=sizeof($responses);
@@ -373,7 +375,7 @@ class MassEntityAPIHandler extends APIHandler
 				{
 					$responseData = $entityResIns->getResponseJSON();
 					$recordJSON = $responseData["details"];
-					
+
 					$updatedRecord = ZCRMRecord::getInstance($this->module->getAPIName(), $recordJSON["id"]+0);
 					EntityAPIHandler::getInstance($updatedRecord)->setRecordProperties($recordJSON);
 					array_push($updatedRecords,$updatedRecord);
@@ -385,7 +387,7 @@ class MassEntityAPIHandler extends APIHandler
 				}
 			}
 			$bulkAPIResponse->setData($updatedRecords);
-				
+
 			return $bulkAPIResponse;
 		}catch (ZCRMException $exception)
 		{
@@ -393,7 +395,7 @@ class MassEntityAPIHandler extends APIHandler
 			throw $exception;
 		}
 	}
-	
+
 	public function constructJSONForMassUpdate($idList,$apiName,$value)
 	{
 		$massUpdateArray=array();
@@ -404,8 +406,7 @@ class MassEntityAPIHandler extends APIHandler
 			$updateJson[$apiName]=$value;
 			array_push($massUpdateArray,$updateJson);
 		}
-		
+
 		return array("data"=>$massUpdateArray);
 	}
 }
-?>


### PR DESCRIPTION
This is the official Zoho API SDK, yet its coding style falls well below today's standards.

Simple things like the following should be addressed:

1) Files ending in PHP code do not need the closing `?>` PHP tag.
2) Whitespace should be consistent.
3) Using `__DIR__` instead of `dirname(__FILE__)`.
4) Using single quotes around strings that don't need parsing or have single quotes within.
5) Using `switch()` where appropriate, instead of endless `if/else()` statements.
6) Using typecasting instead of `$str = "" . $var;` for strings and `$num = $var + 0;` for numbers.

About item (6), the results of that `+ 0` technique are unpredictable. It depends on what value is in the variable. Look over this to see why:

```
Input             Output
'2' + 0           2 (int)
'2.34' + 0        2.34 (float)
'0.3454545' + 0   0.3454545 (float)
```

So it's always better to use (int) or (float) typecasts whenever a specific type is needed.

There are many third-party SDK's for Zoho's API, and one reason may be that this official library does not live up to today's standards. I will provide such improvements in a pull-request if you will review and accept the changes. Please acknowledge this and I will proceed.

Please see the changes made in this pull-request for example updates.