### PR TITLE
Update ZohoHTTPConnector.php

### DIFF
--- a/src/com/zoho/crm/library/common/ZohoHTTPConnector.php
+++ b/src/com/zoho/crm/library/common/ZohoHTTPConnector.php
@@ -31,7 +31,7 @@ class ZohoHTTPConnector
 	public function fireRequest()
 	{
 		$curl_pointer=curl_init();
-		if(count(self::getRequestParamsMap())>0)
+		if(is_array(self::getRequestParamsMap()) && count(self::getRequestParamsMap())>0)
 		{
 			$url=self::getUrl()."?".self::getUrlParamsAsString(self::getRequestParamsMap());
 			curl_setopt($curl_pointer,CURLOPT_URL,$url);


### PR DESCRIPTION
fix warning from `count(NULL)` if `$this->requestParams` load from APIHandler default value (NULL)