### PR TITLE
Fix php7.2

### DIFF
--- a/src/com/zoho/crm/library/common/ZCRMConfigUtil.php
+++ b/src/com/zoho/crm/library/common/ZCRMConfigUtil.php
@@ -56,7 +56,7 @@ class ZCRMConfigUtil
 	    }
 	}
 
-	private function setConfigValues($configuration)
+	private static function setConfigValues($configuration)
 	{
 	    $config_keys = array(APIConstants::CURRENT_USER_EMAIL,ZohoOAuthConstants::SANDBOX,APIConstants::API_BASEURL,
 	        APIConstants::API_VERSION,APIConstants::APPLICATION_LOGFILE_PATH);

--- a/src/com/zoho/crm/library/common/ZohoHTTPConnector.php
+++ b/src/com/zoho/crm/library/common/ZohoHTTPConnector.php
@@ -142,6 +142,10 @@ class ZohoHTTPConnector
 	}
 	public function getRequestParamsMap()
 	{
+		if(!is_array($this->requestParams)) {
+			$this->requestParams = [];
+		}
+
 		return $this->requestParams;
 	}
 	

--- a/src/com/zoho/oauth/client/ZohoOAuth.php
+++ b/src/com/zoho/oauth/client/ZohoOAuth.php
@@ -69,7 +69,7 @@ class ZohoOAuth
 	    }
 	}
 	
-	private function setConfigValues($configuration)
+	private static function setConfigValues($configuration)
 	{
 	    $config_keys = array(ZohoOAuthConstants::CLIENT_ID,ZohoOAuthConstants::CLIENT_SECRET,ZohoOAuthConstants::REDIRECT_URL,ZohoOAuthConstants::ACCESS_TYPE
 			,ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS,ZohoOAuthConstants::IAM_URL,ZohoOAuthConstants::TOKEN_PERSISTENCE_PATH,ZohoOAuthConstants::DATABASE_PORT


### PR DESCRIPTION
Some fixes to work in PHP 7.2:
-Fix Non-static method setConfigValues called statically
-Fix count(): Parameter must be an array or an object that implements countable