### PR TITLE
fix ZohoOAuthHTTPConnector::post()

### DIFF
--- a/src/com/zoho/oauth/common/ZohoOAuthHTTPConnector.php
+++ b/src/com/zoho/oauth/common/ZohoOAuthHTTPConnector.php
@@ -10,9 +10,8 @@ class ZohoOAuthHTTPConnector
 	public function post()
 	{
 		$curl_pointer=curl_init();
-		curl_setopt($curl_pointer,CURLOPT_URL,self::getUrl());
+		curl_setopt($curl_pointer,CURLOPT_URL,self::getUrl().'?'.self::getUrlParamsAsString($this->requestParams));
 		curl_setopt($curl_pointer,CURLOPT_HEADER,1);
-		curl_setopt($curl_pointer,CURLOPT_POSTFIELDS,self::getUrlParamsAsString($this->requestParams));
 		curl_setopt($curl_pointer,CURLOPT_RETURNTRANSFER,true);
 		curl_setopt($curl_pointer,CURLOPT_USERAGENT,'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13');
 		curl_setopt($curl_pointer,CURLOPT_HTTPHEADER,self::getRequestHeadersAsArray());


### PR DESCRIPTION
ZohoOAuthHTTPConnector::post() returns 405 otherwise