### PR TITLE
fixed phpunit exception thrown when params map is null

### DIFF
--- a/src/com/zoho/crm/library/common/ZohoHTTPConnector.php
+++ b/src/com/zoho/crm/library/common/ZohoHTTPConnector.php
@@ -31,7 +31,7 @@ class ZohoHTTPConnector
 	public function fireRequest()
 	{
 		$curl_pointer=curl_init();
-		if(count(self::getRequestParamsMap())>0)
+		if (self::getRequestParamsMap() && count(self::getRequestParamsMap()) > 0)
 		{
 			$url=self::getUrl()."?".self::getUrlParamsAsString(self::getRequestParamsMap());
 			curl_setopt($curl_pointer,CURLOPT_URL,$url);


### PR DESCRIPTION
When `self::getRequestParamsMap()` returns null then an exception is thrown when called from within PHPUnit tests because it is not countable.

`PHP Warning:  count(): Parameter must be an array or an object that implements Countable`