### PR TITLE
Logger -> ZCRMLogger

### DIFF
--- a/src/com/zoho/crm/library/common/CommonUtil.php
+++ b/src/com/zoho/crm/library/common/CommonUtil.php
@@ -1,5 +1,5 @@
 <?php
-require_once realpath(dirname(__FILE__)."/../exception/Logger.php");
+require_once realpath(dirname(__FILE__)."/../exception/ZCRMLogger.php");
 class CommonUtil
 {
 	public static function getFileContentAsMap($fileHandler)
@@ -19,7 +19,7 @@ class CommonUtil
 		}
 		catch (Exception $ex)
 		{
-			Logger::warn("Exception occured while converting file content as map (file::ZohoOAuthUtil.php)");
+			ZCRMLogger::warn("Exception occured while converting file content as map (file::ZohoOAuthUtil.php)");
 		}
 		return $reponseMap;
 	}

--- a/src/com/zoho/crm/library/exception/APIExceptionHandler.php
+++ b/src/com/zoho/crm/library/exception/APIExceptionHandler.php
@@ -1,5 +1,5 @@
 <?php
-require_once 'Logger.php';
+require_once 'ZCRMLogger.php';
 require_once realpath(dirname(__FILE__)."/../common/APIConstants.php");
 
 class APIExceptionHandler
@@ -8,7 +8,7 @@ class APIExceptionHandler
 	{
 		$msg=get_class($e)." Caused by:'{$e->getMessage()}' in {$e->getFile()}({$e->getLine()})\nTrace::".$e->getTraceAsString();
 		$message=$e->getMessage().";;Trace::".$e->getTraceAsString();
-		Logger::err($msg);
+		ZCRMLogger::err($msg);
 	}
 	
 	public static function getFaultyResponseCodes()

--- a/src/com/zoho/crm/library/exception/ZCRMLogger.php
+++ b/src/com/zoho/crm/library/exception/ZCRMLogger.php
@@ -1,6 +1,6 @@
 <?php
 require_once realpath(dirname(__FILE__)."/../common/ZCRMConfigUtil.php");
-class Logger
+class ZCRMLogger
 {
 	public static function writeToFile($msg)
 	{


### PR DESCRIPTION
This changes the Logger class to ZCRMLogger because Logger class is very common and we had a project where it was conflicting.

It's actually better to make all of the library with a namespace, but this is a least a quick fix for now :)
