### PR TITLE
persistence handler class from params

### DIFF
--- a/src/com/zoho/oauth/client/ZohoOAuth.php
+++ b/src/com/zoho/oauth/client/ZohoOAuth.php
@@ -158,7 +158,7 @@ class ZohoOAuth
 	{
 		try
 		{
-			return ZohoOAuth::getConfigValue("token_persistence_path")!=""?new ZohoOAuthPersistenceByFile():new ZohoOAuthPersistenceHandler();
+			return ZohoOAuth::getConfigValue("token_persistence_path")!=""?new ZohoOAuthPersistenceByFile():new self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS];
 		}
 		catch (Exception $ex)
 		{

--- a/src/com/zoho/oauth/clientapp/ZohoOAuthPersistenceHandler.php
+++ b/src/com/zoho/oauth/clientapp/ZohoOAuthPersistenceHandler.php
@@ -97,8 +97,8 @@ class ZohoOAuthPersistenceHandler implements ZohoOAuthPersistenceInterface
 	
 	public function getMysqlConnection()
 	{
-		$mysqli_con = new mysqli("localhost:".ZohoOAuth::getConfigValue(ZohoOAuthConstants::DATABASE_PORT),ZohoOAuth::getConfigValue(ZohoOAuthConstants::DATABASE_USERNAME), 
-		ZohoOAuth::getConfigValue(ZohoOAuthConstants::DATABASE_PASSWORD), "zohooauth");
+		$mysqli_con = new mysqli("localhost",ZohoOAuth::getConfigValue(ZohoOAuthConstants::DATABASE_USERNAME),
+		ZohoOAuth::getConfigValue(ZohoOAuthConstants::DATABASE_PASSWORD), "zohooauth", ZohoOAuth::getConfigValue(ZohoOAuthConstants::DATABASE_PORT));
 		if ($mysqli_con->connect_errno) {
 			OAuthLogger::severe("Failed to connect to MySQL: (" . $mysqli_con->connect_errno . ") " . $mysqli_con->connect_error);
 			echo "Failed to connect to MySQL: (" . $mysqli_con->connect_errno . ") " . $mysqli_con->connect_error;


### PR DESCRIPTION
these changes will help users to customize the way of working with the database without affecting the source code, now there is a need to edit them after each deployment, and there was mistake in arguments for `mysqli` Class