### PR TITLE
Issue with set_include_path

### DIFF
--- a/src/crm/utility/Logger.php
+++ b/src/crm/utility/Logger.php
@@ -6,7 +6,7 @@ class Logger
     
     public static function writeToFile($msg)
     {
-        set_include_path(ZCRMConfigUtil::getConfigValue('applicationLogFilePath'));
+        set_include_path(get_include_path() . PATH_SEPARATOR . ZCRMConfigUtil::getConfigValue('applicationLogFilePath'));
         $path = get_include_path();
         if (!ZCRMConfigUtil::getConfigValue('applicationLogFilePath')) {
             $path=dirname(__FILE__) ."/../../..";

--- a/src/oauth/persistence/ZohoOAuthPersistenceByFile.php
+++ b/src/oauth/persistence/ZohoOAuthPersistenceByFile.php
@@ -14,7 +14,7 @@ class ZohoOAuthPersistenceByFile implements ZohoOAuthPersistenceInterface
     {
         $path = ZohoOAuth::getConfigValue('token_persistence_path');
         $path = trim($path);
-        set_include_path($path);
+        set_include_path(get_include_path() . PATH_SEPARATOR . $path);
     }
     
     public function saveOAuthData($zohoOAuthTokens)


### PR DESCRIPTION
There is an issue when you include the library in a platform like Magento. This kind of platform defines a include_path, and currently the set_include_path overwrite the path originally defined which cause issues. It would be better to add Zoho API path to the original path.