### PR TITLE
Use correct OAuthLogger::severe in ZohoOAuthPersistenceHandler saveOAuthData (not a wrong unknown Logger)

### DIFF
--- a/src/oauth/persistence/ZohoOAuthPersistenceHandler.php
+++ b/src/oauth/persistence/ZohoOAuthPersistenceHandler.php
@@ -24,8 +24,7 @@ class ZohoOAuthPersistenceHandler implements ZohoOAuthPersistenceInterface
                 OAuthLogger::severe("OAuth token insertion failed: (" . $db_link->errno . ") " . $db_link->error);
             }
         } catch (Exception $ex) {
-            Logger:
-            severe("Exception occured while inserting OAuthTokens into DB(file::ZohoOAuthPersistenceHandler)({$ex->getMessage()})\n{$ex}");
+            OAuthLogger::severe("Exception occured while inserting OAuthTokens into DB(file::ZohoOAuthPersistenceHandler)({$ex->getMessage()})\n{$ex}");
         } finally {
             if ($db_link != null) {
                 $db_link->close();


### PR DESCRIPTION
hi,
if ZohoOAuthPersistenceHandler saveOAuthData
catches an exception a wrong unknown Logger was used
resulting in a program error.
thanks,
Noud