### PR TITLE
Allow more configurable persistence handler

### DIFF
--- a/src/oauth/ZohoOAuth.php
+++ b/src/oauth/ZohoOAuth.php
@@ -5,14 +5,15 @@ use Exception;
 use zcrmsdk\oauth\exception\ZohoOAuthException;
 use zcrmsdk\oauth\persistence\ZohoOAuthPersistenceByFile;
 use zcrmsdk\oauth\persistence\ZohoOAuthPersistenceHandler;
+use zcrmsdk\oauth\persistence\ZohoOAuthPersistenceInterface;
 use zcrmsdk\oauth\utility\ZohoOAuthConstants;
 use zcrmsdk\oauth\utility\ZohoOAuthParams;
 
 class ZohoOAuth
 {
-    
+
     private static $configProperties = array();
-    
+
     public static function initialize($configuration)
     {
         self::setConfigValues($configuration);
@@ -34,7 +35,7 @@ class ZohoOAuth
         $oAuthParams->setRedirectURL(self::getConfigValue(ZohoOAuthConstants::REDIRECT_URL));
         ZohoOAuthClient::getInstance($oAuthParams);
     }
-    
+
     private static function setConfigValues($configuration)
     {
         $config_keys = array(
@@ -49,91 +50,92 @@ class ZohoOAuth
             ZohoOAuthConstants::DATABASE_PASSWORD,
             ZohoOAuthConstants::DATABASE_USERNAME
         );
-        
+
         if (! array_key_exists(ZohoOAuthConstants::ACCESS_TYPE, $configuration) || $configuration[ZohoOAuthConstants::ACCESS_TYPE] == "") {
             self::$configProperties[ZohoOAuthConstants::ACCESS_TYPE] = "offline";
         }
         if (! array_key_exists(ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS, $configuration) || $configuration[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS] == "") {
-            self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS] = "ZohoOAuthPersistenceHandler";
+            self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS] = ZohoOAuthPersistenceHandler::class;
         }
         if (! array_key_exists(ZohoOAuthConstants::IAM_URL, $configuration) || $configuration[ZohoOAuthConstants::IAM_URL] == "") {
             self::$configProperties[ZohoOAuthConstants::IAM_URL] = "https://accounts.zoho.com";
         }
-        
+
         foreach ($config_keys as $key) {
             if (array_key_exists($key, $configuration))
                 self::$configProperties[$key] = $configuration[$key];
         }
     }
-    
+
     public static function getConfigValue($key)
     {
         return self::$configProperties[$key];
     }
-    
+
     public static function getAllConfigs()
     {
         return self::$configProperties;
     }
-    
+
     public static function getIAMUrl()
     {
         return self::getConfigValue(ZohoOAuthConstants::IAM_URL);
     }
-    
+
     public static function getGrantURL()
     {
         return self::getIAMUrl() . "/oauth/v2/auth";
     }
-    
+
     public static function getTokenURL()
     {
         return self::getIAMUrl() . "/oauth/v2/token";
     }
-    
+
     public static function getRefreshTokenURL()
     {
         return self::getIAMUrl() . "/oauth/v2/token";
     }
-    
+
     public static function getRevokeTokenURL()
     {
         return self::getIAMUrl() . "/oauth/v2/token/revoke";
     }
-    
+
     public static function getUserInfoURL()
     {
         return self::getIAMUrl() . "/oauth/user/info";
     }
-    
+
     public static function getClientID()
     {
         return self::getConfigValue(ZohoOAuthConstants::CLIENT_ID);
     }
-    
+
     public static function getClientSecret()
     {
         return self::getConfigValue(ZohoOAuthConstants::CLIENT_SECRET);
     }
-    
+
     public static function getRedirectURL()
     {
         return self::getConfigValue(ZohoOAuthConstants::REDIRECT_URL);
     }
-    
+
     public static function getAccessType()
     {
         return self::getConfigValue(ZohoOAuthConstants::ACCESS_TYPE);
     }
-    
+
     public static function getPersistenceHandlerInstance()
     {
         try {
             if(ZohoOAuth::getConfigValue("token_persistence_path")!=""){
                 return new ZohoOAuthPersistenceByFile() ;
             }
-            else if(self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS] == "ZohoOAuthPersistenceHandler"){
-                return new ZohoOAuthPersistenceHandler();
+            else if(class_exists(self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS])){
+                $className = self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS];
+                return new $className();
             }
             else{
                 require_once  realpath(self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS]);
@@ -144,12 +146,12 @@ class ZohoOAuth
             throw new ZohoOAuthException($ex);
         }
     }
-    
+
     public static function getClientInstance()
     {
         if (ZohoOAuthClient::getInstanceWithOutParam() == null) {
             throw new ZohoOAuthException("ZCRMRestClient::initialize(\$configMap) must be called before this.");
-            
+
         }
         return ZohoOAuthClient::getInstanceWithOutParam();
     }


### PR DESCRIPTION
When providing a persistence handler in config, allow some more
flexibility. Allow the class name to include the namespace. Just check
if the configured class exists rather than requiring an exact class name
with no namespace when instantiating directly.