### PR TITLE
Allow parameters in the EntityAPIHandler->getRecords() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .project
 .buildpath
+.idea/
 /vendor
 /.settings

--- a/src/crm/api/handler/EntityAPIHandler.php
+++ b/src/crm/api/handler/EntityAPIHandler.php
@@ -28,13 +28,16 @@ class EntityAPIHandler extends APIHandler
     {
         return new EntityAPIHandler($zcrmrecord);
     }
-    
-    public function getRecord()
+
+    public function getRecord(array $params = null)
     {
         try {
             $this->requestMethod = APIConstants::REQUEST_METHOD_GET;
             $this->urlPath = $this->record->getModuleApiName() . "/" . $this->record->getEntityId();
             $this->addHeader("Content-Type", "application/json");
+            if (!is_null($params)) {
+                $this->setRequestParams($params);
+            }
             $responseInstance = APIRequest::getInstance($this)->getAPIResponse();
             $recordDetails = $responseInstance->getResponseJSON()['data'];
             self::setRecordProperties($recordDetails[0]);

--- a/src/crm/api/handler/EntityAPIHandler.php
+++ b/src/crm/api/handler/EntityAPIHandler.php
@@ -29,15 +29,13 @@ class EntityAPIHandler extends APIHandler
         return new EntityAPIHandler($zcrmrecord);
     }
 
-    public function getRecord(array $params = null)
+    public function getRecord(array $params = array())
     {
         try {
             $this->requestMethod = APIConstants::REQUEST_METHOD_GET;
             $this->urlPath = $this->record->getModuleApiName() . "/" . $this->record->getEntityId();
             $this->addHeader("Content-Type", "application/json");
-            if (!is_null($params)) {
-                $this->setRequestParams($params);
-            }
+            $this->setRequestParams($params);
             $responseInstance = APIRequest::getInstance($this)->getAPIResponse();
             $recordDetails = $responseInstance->getResponseJSON()['data'];
             self::setRecordProperties($recordDetails[0]);


### PR DESCRIPTION
This allows for any key/value pair to be added to the requestParams when using the `getRecords()` method in the EntityAPIHandler class.