### PR TITLE
Inject an instantiated persistence handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 ----------------------
 PHP SDK for Zoho CRM APIs provides wrapper for Zoho CRM APIs. Hence invoking a Zoho CRM API from your client application is just a method call.It supports both single user as well as multi user authentication.
 
+Currently using this bundle for payments at (https://www.parolla.ie)](https://www.parolla.ie) and (https://tools.parolla.ie)](https://tools.parolla.ie)
+
 Registering a Zoho Client
 -------------------------
 Since Zoho CRM APIs are authenticated with OAuth2 standards, you should register your client app with Zoho. To register your app:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 ----------------------
 PHP SDK for Zoho CRM APIs provides wrapper for Zoho CRM APIs. Hence invoking a Zoho CRM API from your client application is just a method call.It supports both single user as well as multi user authentication.
 
-Currently using this bundle for payments at (https://www.parolla.ie)](https://www.parolla.ie) and (https://tools.parolla.ie)](https://tools.parolla.ie)
-
 Registering a Zoho Client
 -------------------------
 Since Zoho CRM APIs are authenticated with OAuth2 standards, you should register your client app with Zoho. To register your app:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ apiBaseUrl
 apiVersion
 access_type
 accounts_url
+persistence_handler
 persistence_handler_class
 token_persistence_path
 db_port
@@ -111,7 +112,9 @@ applicationLogFilePath - The SDK stores the log information in a file.
     The file path of the folder must be specified in the key and the SDK automatically creates the file. The default file name is the ZCRMClientLibrary.log.
     In case the path isn't specified, the log file will be created inside the project.
 
-persistence_handler_class is the implementation of the ZohoOAuthPersistenceInterface.
+persistence_handler_class is the implementation of the ZohoOAuthPersistenceInterface. This will instantiate a class based on the file location. eg \home\php\CustomPersistence.php
+
+persistence_handler - You can inject an instantiated persistence hander into the configuration during run time to pass yourcustom persistence handler to the XohoOAuth class.
 
 >If the Optional keys are not specified, their default values will be assigned automatically.
 >The 'apiBaseUrl' and 'accounts_url' are mandatory in case the user is not in the "com" domain. 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"autoload" : {
 		"psr-4" : {
-			"zcrmsdk\\" : "src"
+			"zcrmsdk\\" : "src/"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"autoload" : {
 		"psr-4" : {
-			"zcrmsdk\\" : "src/"
+			"zcrmsdk\\" : "src"
 		}
 	}
 }

--- a/src/crm/exception/ZCRMException.php
+++ b/src/crm/exception/ZCRMException.php
@@ -11,13 +11,7 @@ class ZCRMException extends \Exception
     
     // Unknown
     protected $code = 0;
-    
-    // User-defined exception code
-    protected $file;
-    
-    // Source filename of exception
-    protected $line;
-    
+       
     // Source line of exception
     private $trace;
     

--- a/src/oauth/ZohoOAuth.php
+++ b/src/oauth/ZohoOAuth.php
@@ -48,6 +48,7 @@ class ZohoOAuth
             ZohoOAuthConstants::CLIENT_SECRET,
             ZohoOAuthConstants::REDIRECT_URL,
             ZohoOAuthConstants::ACCESS_TYPE,
+            ZohoOAuthConstants::PERSISTENCE_HANDLER,
             ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS,
             ZohoOAuthConstants::IAM_URL,
             ZohoOAuthConstants::TOKEN_PERSISTENCE_PATH,
@@ -139,6 +140,9 @@ class ZohoOAuth
         try {
             if(ZohoOAuth::getConfigValue("token_persistence_path")!=""){
                 return new ZohoOAuthPersistenceByFile() ;
+            }
+            else if(self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER] instanceof ZohoOAuthPersistenceInterface){
+                return self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER];
             }
             else if(self::$configProperties[ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS] == "ZohoOAuthPersistenceHandler"){
                 return new ZohoOAuthPersistenceHandler();

--- a/src/oauth/ZohoOAuth.php
+++ b/src/oauth/ZohoOAuth.php
@@ -5,6 +5,7 @@ use Exception;
 use zcrmsdk\oauth\exception\ZohoOAuthException;
 use zcrmsdk\oauth\persistence\ZohoOAuthPersistenceByFile;
 use zcrmsdk\oauth\persistence\ZohoOAuthPersistenceHandler;
+use zcrmsdk\oauth\persistence\ZohoOAuthPersistenceInterface;
 use zcrmsdk\oauth\utility\ZohoOAuthConstants;
 use zcrmsdk\oauth\utility\ZohoOAuthParams;
 

--- a/src/oauth/utility/ZohoOAuthConstants.php
+++ b/src/oauth/utility/ZohoOAuthConstants.php
@@ -52,6 +52,8 @@ class ZohoOAuthConstants
     
     const EXPIRIY_TIME = "expiry_time";
     
+    const PERSISTENCE_HANDLER = "persistence_handler";
+    
     const PERSISTENCE_HANDLER_CLASS = "persistence_handler_class";
     
     const PERSISTENCE_HANDLER_CLASS_NAME = "persistence_handler_class_name";


### PR DESCRIPTION
Hi, the current method of creating a custom persistence handler doest allow the developer access to the constructor or setter methods.

Instead, consider injecting a custom persistence handler. I've done this by adding the custom handler to the config array at run time.

Although better yet would be a setter method.