### PR TITLE
Support an alternate database for Oauth interactions

### DIFF
--- a/src/oauth/ZohoOAuth.php
+++ b/src/oauth/ZohoOAuth.php
@@ -55,7 +55,8 @@ class ZohoOAuth
             ZohoOAuthConstants::DATABASE_PASSWORD,
             ZohoOAuthConstants::DATABASE_USERNAME,
             ZohoOAuthConstants::PERSISTENCE_HANDLER_CLASS_NAME,
-            ZohoOAuthConstants::HOST_ADDRESS
+            ZohoOAuthConstants::HOST_ADDRESS,
+            ZohoOAuthConstants::DATABASE_NAME
         );
         
         if (! array_key_exists(ZohoOAuthConstants::ACCESS_TYPE, $configuration) || $configuration[ZohoOAuthConstants::ACCESS_TYPE] == "") {


### PR DESCRIPTION
This is the other half of #45. `HOST_ADDRESS` support was already added a while back, but `DATABASE_NAME` still needs added in there. 