### PR TITLE
API URL is wrong when I use URL with https://

### DIFF
--- a/src/crm/api/APIRequest.php
+++ b/src/crm/api/APIRequest.php
@@ -46,7 +46,7 @@ class APIRequest
         {
             self::constructAPIUrl($apiHandler);
             self::setUrl($this->url . $apiHandler->getUrlPath());
-            if (substr($apiHandler->getUrlPath(), 0, 4) !== "http")
+            if (substr($this->url, 0, 4) !== "http")
             {
                 self::setUrl("https://" . $this->url);
             }


### PR DESCRIPTION
If I init the Client like:

```
ZCRMRestClient::initialize(array(
            'access_type' => 'offline',
            'accounts_url' => 'https://accounts.zoho.eu',
            'apiBaseUrl' => 'https://www.zohoapis.eu'
));
```

I got double https://https:// on curl request.

I think the problem is comming from the like I changed!