### PR TITLE
updated code to work with php 8.1.2

### DIFF
--- a/src/oauth/exception/ZohoOAuthException.php
+++ b/src/oauth/exception/ZohoOAuthException.php
@@ -12,12 +12,6 @@ class ZohoOAuthException extends \Exception
     // Unknown
     protected $code = 0;
     
-    // User-defined exception code
-    protected $file;
-    
-    // Source filename of exception
-    protected $line;
-    
     // Source line of exception
     private $trace;
     


### PR DESCRIPTION
ZohoOAuthException is not compatible with 8.1.2 due to $file not declared string and $line not declared as int