### PR TITLE
Provide an option to unset field values.

### DIFF
--- a/src/crm/crud/ZCRMRecord.php
+++ b/src/crm/crud/ZCRMRecord.php
@@ -267,7 +267,17 @@ class ZCRMRecord
     {
         $this->fieldNameVsValue[$apiName] = $value;
     }
-    
+
+    /**
+     * Unset field value
+     *
+     * @param String $apiName api name of the field.
+     */
+    public function unsetFieldValue($apiName,)
+    {
+        unset($this->fieldNameVsValue[$apiName]);
+    }
+
     /**
      * Method to get an array(key-value pair) containing field name as key and field data as value for the record
      *

--- a/src/crm/crud/ZCRMRecord.php
+++ b/src/crm/crud/ZCRMRecord.php
@@ -269,11 +269,11 @@ class ZCRMRecord
     }
 
     /**
-     * Unset field value
+     * Unset field value.
      *
      * @param String $apiName api name of the field.
      */
-    public function unsetFieldValue($apiName,)
+    public function unsetFieldValue($apiName)
     {
         unset($this->fieldNameVsValue[$apiName]);
     }


### PR DESCRIPTION
This is required in the case of image fields.
By Default Record_Image field is set to null which is causing the below message to appear in the account timeline.
"Account image deleted"

This is unnecessary and caused due to default null value for Record_image property.